### PR TITLE
fix compare-excel export bug.

### DIFF
--- a/packages/outreader-client/package.json
+++ b/packages/outreader-client/package.json
@@ -61,7 +61,7 @@
       ]
     },
     "win": {
-      "target": ["nsis", "msi"]
+      "target": ["portable"]
     },
     "linux": {
       "target": ["deb", "rpm", "AppImage"],

--- a/packages/outreader-core/src/compare-excel/factor.ts
+++ b/packages/outreader-core/src/compare-excel/factor.ts
@@ -55,14 +55,14 @@ export async function writeFactor(
 
     count =
       Math.max(
-        structures[i].factor.stiffness.storeyID[0],
-        structures[i].factor.v02qFactor.storeyID[0],
-        structures[i].factor.shearWeightRatioModify.storeyID[0],
+        structures[i].factor.stiffness.storeyID[0] || 0,
+        structures[i].factor.v02qFactor.storeyID[0] || 0,
+        structures[i].factor.shearWeightRatioModify.storeyID[0] || 0,
       ) > count
         ? Math.max(
-            structures[i].factor.stiffness.storeyID[0],
-            structures[i].factor.v02qFactor.storeyID[0],
-            structures[i].factor.shearWeightRatioModify.storeyID[0],
+            structures[i].factor.stiffness.storeyID[0] || 0,
+            structures[i].factor.v02qFactor.storeyID[0] || 0,
+            structures[i].factor.shearWeightRatioModify.storeyID[0] || 0,
           )
         : count;
   }


### PR DESCRIPTION
修复：
1、调整系数缺失时对比表格Excel输出错误：某个调整系数（薄弱层调整系数、0.2V0调整系数、剪重比调整系数之一）缺失时storeyID参数为undefined，读取不到最大楼层数输出Excel时引起错误。修复后当storeyID参数为undefined时取0做比较。

调整：
1、打包免安装版本win程序。