### PR TITLE
fix yjk tube structure 02v0q factor extract error.

### DIFF
--- a/packages/outreader-yjk/src/wv02q/wv02q.ts
+++ b/packages/outreader-yjk/src/wv02q/wv02q.ts
@@ -221,7 +221,10 @@ export function extractv02qFactor(
       v02qFactor.storeyID.push(Number(lineArray[1]));
       v02qFactor.towerID.push(Number(lineArray[3]));
     }
-    if (!isNaN(Number(lineArray[0])) && lineArray.length === 4) {
+    if (
+      !isNaN(Number(lineArray[0])) &&
+      (lineArray.length === 4 || lineArray.length === 6)
+    ) {
       v02qFactor.factorX.push(Number(lineArray[0]));
       v02qFactor.factorY.push(Number(lineArray[1]));
     }


### PR DESCRIPTION
修复：
1、筒体结构0.2V0调整系数读取错误，筒体结构0.2V0调整系数数据格式与其他结构形式不同，以前版读取失败，修复筒体结构0.2V0调整系数读取。